### PR TITLE
misspelled enabled

### DIFF
--- a/client/src/user/DashboardSeller.jsx
+++ b/client/src/user/DashboardSeller.jsx
@@ -84,7 +84,7 @@ const DashboardSeller = () => {
         <div className='container-fluid p-4'>
             <DashboardNav/>
         </div>
-        { auth && auth.user && auth.user.stripe_seller && auth.user.stripe_seller.charges_enable ? connected() : notConnected()}
+        { auth && auth.user && auth.user.stripe_seller && auth.user.stripe_seller.charges_enabled ? connected() : notConnected()}
     </>
   )
 }


### PR DESCRIPTION
you misspelled charges_enabled. 
stripe response as "charges_enabled" not "charges_enable"